### PR TITLE
Display FPS in debug menu

### DIFF
--- a/client/main/index.js
+++ b/client/main/index.js
@@ -46,7 +46,7 @@ class Main extends React.Component {
                             <ContentPanel />
                         </div>
                         <div className={`col-md-6 pl-0 pr-0 ${css.tools}`}>
-                            <ToolPanel />
+                            <ToolPanel fps={this.state.fps} />
                         </div>
                         <div className={`col-md-3 pl-0 pr-0 ${css.nodes}`}>
                             <NodePanel />

--- a/client/main/interface/tools/view/fps.js
+++ b/client/main/interface/tools/view/fps.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default class FPS extends React.Component {
+export class FPS extends React.Component {
     render() {
-        return <h2>{this.props.fps.toFixed(0)} FPS</h2>;
+        return <span>{this.props.fps.toFixed(0)} FPS</span>;
     }
 }
 

--- a/client/main/interface/tools/view/tool-panel.js
+++ b/client/main/interface/tools/view/tool-panel.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import FontAwesome from 'react-fontawesome'
+import PropTypes from 'prop-types'
+import {FPS} from './fps'
 import {
     togglePointerLock,
     setTranslate,
@@ -50,12 +52,10 @@ export class ToolPanel extends React.Component {
                             </select>
                         </div>
                         <div className='col'>
-                            <button type='button' className='btn btn-sm btn-outline-light'>
-                                <span>FPS</span>
-                            </button>
                             <button type='button' className='btn btn-sm btn-outline-light' onClick={togglePointerLock}>
                                 <FontAwesome name='video-camera' />
                             </button>
+                            <FPS fps={this.props.fps} />
                         </div>
                     </div>
                 </div>
@@ -71,3 +71,7 @@ export class ToolPanel extends React.Component {
         }
     }
 }
+
+ToolPanel.propTypes = {
+    fps: PropTypes.number.isRequired
+};


### PR DESCRIPTION
The logic to track frames per second (FPS) was added in a much earlier version of Era, but was removed as part of a UI overhaul. This PR restores the FPS functionality, replacing the FPS button on the debug menu with a functional FPS counter.

Before:
![old](https://user-images.githubusercontent.com/7778111/60410107-794ec980-9b7b-11e9-9b41-e3bd655a7f3b.jpg)

After:
![new](https://user-images.githubusercontent.com/7778111/60410109-7eac1400-9b7b-11e9-92ff-ada039dc41d2.png)
