### PR TITLE
Fix client links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ include React, Redux, Webpack, and WebGL. It is broken up into the following maj
 
 ### Commands
 Run these commands from the `client` directory:
-- `npm run dev`: Runs the development version of the client (accessible at `http://localhost:8080/dist`)
-- `npm run prod`: Runs the production version of the client (accessible at `http://localhost:8080/dist`)
+- `npm run dev`: Runs the development version of the client (accessible at `http://localhost:8080`)
+- `npm run prod`: Runs the production version of the client (accessible at `http://localhost:8080`)
 - `npm test`: Runs the unit tests with [Karma](https://karma-runner.github.io/2.0/index.html) (Google Chrome required)
 
 ### Configuration


### PR DESCRIPTION
After merging #3, the link to access the client changed from `http://localhost:8080/dist` to `http://localhost:8080`. This PR updates the readme file to reflect this.