### PR TITLE
Add script to fix linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Run these commands from the `client` directory:
 - `npm run dev`: Runs the development version of the client (accessible at `http://localhost:8080`)
 - `npm run prod`: Runs the production version of the client (accessible at `http://localhost:8080`)
 - `npm test`: Runs the unit tests with [Karma](https://karma-runner.github.io/2.0/index.html) (Google Chrome required)
-- `npm run lint`: Fix linting errors in the client source code
+- `npm run fix`: Fix linting errors in the client source code
 
 ### Configuration
 The client configuration file is located at `client/main/config.js` and defines the URL of the server to
@@ -66,7 +66,7 @@ Run these commands from the `server` directory:
   - Requires connection to `mongodb://localhost/app`
 - `npm test`: Runs the integration tests
   - Requires connection to `mongodb://localhost/test`
--  `npm run lint`: Fix linting errors in the server source code
+-  `npm run fix`: Fix linting errors in the server source code
 
 ### Configuration
 The server configuration file is located at `server/main/config.js` and allows modification of the following values:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Run these commands from the `client` directory:
 - `npm run dev`: Runs the development version of the client (accessible at `http://localhost:8080`)
 - `npm run prod`: Runs the production version of the client (accessible at `http://localhost:8080`)
 - `npm test`: Runs the unit tests with [Karma](https://karma-runner.github.io/2.0/index.html) (Google Chrome required)
+- `npm run lint`: Fix linting errors in the client source code
 
 ### Configuration
 The client configuration file is located at `client/main/config.js` and defines the URL of the server to
@@ -65,6 +66,7 @@ Run these commands from the `server` directory:
   - Requires connection to `mongodb://localhost/app`
 - `npm test`: Runs the integration tests
   - Requires connection to `mongodb://localhost/test`
+-  `npm run lint`: Fix linting errors in the server source code
 
 ### Configuration
 The server configuration file is located at `server/main/config.js` and allows modification of the following values:

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "webpack-dev-server",
     "prod": "cross-env NODE_ENV=production webpack-dev-server -p",
-    "test": "karma start karma.config.js"
+    "test": "karma start karma.config.js",
+    "fix": "eslint --fix main"
   },
   "dependencies": {
     "bootstrap": "^4.0.0-beta",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "start": "nodemon --ignore dist/ --exec \"npm run init\"",
     "init": "rimraf dist/ && tsc && copyfiles -u 1 \"main/view/**\" dist && node dist/app.js",
-    "test": "cross-env NODE_ENV=test mocha --exit --reporter spec --require ts-node/register main/**/**.test.js"
+    "test": "cross-env NODE_ENV=test mocha --exit --reporter spec --require ts-node/register main/**/**.test.js",
+    "fix": "eslint --fix main"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",


### PR DESCRIPTION
This PR adds a `fix` script to the client and server `package.json`. This script runs `eslint --fix` to fix linting errors in the source code.